### PR TITLE
Completed the  Deployment Script for StudyDAO.sol

### DIFF
--- a/smart_contract/ignition/modules/StudyDAO.js
+++ b/smart_contract/ignition/modules/StudyDAO.js
@@ -1,0 +1,26 @@
+// File: ignition/modules/StudyDAO.js
+const { buildModule } = require("@nomicfoundation/hardhat-ignition/modules");
+const fs = require("fs");
+const path = require("path");
+
+module.exports = buildModule("StudyDAOModule", (m) => {
+  const studyDAO = m.contract("StudyDAO");
+
+  m.call(studyDAO, "_", {
+    afterDeploy: async () => {
+      const dir = path.join(__dirname, "../../client/src/contract_data/");
+      
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+      fs.writeFileSync(
+        path.join(dir, "StudyDAO-address.json"),
+        JSON.stringify({ address: studyDAO.target,deployedAt: new Date().toISOString() }, null, 2) );
+
+      const artifact = await hre.artifacts.readArtifact("StudyDAO");
+      fs.writeFileSync(path.join(dir, "StudyDAO.json"),JSON.stringify(artifact, null, 2)
+      );
+      console.log(` Contract data is now saved to ${dir}`);
+    }
+  });
+  return { studyDAO };
+});


### PR DESCRIPTION
The script now uses Ignition to deploy your StudyDAO contract in the simplest way possible, while keeping all the code in one file. After deployment, it automatically saves the contract address and ABI to the frontend's contract_data folder, creating the folder if it doesn't exist. The path is correctly set to work with your project structure. Everything happens in a single step when you run the deploy command using hardhat

Resolves #2 